### PR TITLE
feat: Added new resources and arguments

### DIFF
--- a/examples/standard/example.tf
+++ b/examples/standard/example.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
-
+data "aws_partition" "current" {}
 
 module "sqs" {
   source = "./../../"
@@ -19,6 +19,25 @@ module "sqs" {
   receive_wait_time_seconds = 10
   sqs_managed_sse_enabled   = true
   policy                    = data.aws_iam_policy_document.document.json
+
+  create_queue_policy = true
+
+  queue_policy_statements = {
+    account = {
+      sid = "AllowAllAccount"
+      actions = [
+        "sqs:SendMessage",
+        "sqs:ReceiveMessage",
+      ]
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
+        }
+      ]
+    }
+  }
+
 }
 
 data "aws_iam_policy_document" "document" {

--- a/examples/standard/outputs.tf
+++ b/examples/standard/outputs.tf
@@ -7,3 +7,18 @@ output "tags" {
   value       = module.sqs.tags
   description = "A mapping of tags to assign to the alb."
 }
+
+output "queue_policy_document" {
+  value       = module.sqs.queue_policy_document
+  description = "Policy document generated inside the SQS module"
+}
+
+output "queue_policy" {
+  value       = module.sqs.queue_policy
+  description = "Policy attached to the SQS queue"
+}
+
+output "queue_with_policy_url" {
+  value       = module.sqs.queue_with_policy_url
+  description = "Queue URL with attached policy"
+}

--- a/main.tf
+++ b/main.tf
@@ -39,3 +39,65 @@ resource "aws_sqs_queue" "default" {
   kms_data_key_reuse_period_seconds = var.kms_data_key_reuse_period_seconds
   tags                              = module.labels.tags
 }
+
+
+data "aws_partition" "current" {}
+
+data "aws_iam_policy_document" "this" {
+  count = var.enabled && var.create_queue_policy ? 1 : 0
+
+  source_policy_documents   = var.source_queue_policy_documents
+  override_policy_documents = var.override_queue_policy_documents
+
+  dynamic "statement" {
+    for_each = var.queue_policy_statements
+
+    content {
+      sid           = try(statement.value.sid, null)
+      actions       = try(statement.value.actions, null)
+      not_actions   = try(statement.value.not_actions, null)
+      effect        = try(statement.value.effect, null)
+      resources     = try(statement.value.resources, [aws_sqs_queue.default[0].arn])
+      not_resources = try(statement.value.not_resources, null)
+
+      dynamic "principals" {
+        for_each = try(statement.value.principals, [])
+
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+
+      dynamic "not_principals" {
+        for_each = try(statement.value.not_principals, [])
+
+        content {
+          type        = not_principals.value.type
+          identifiers = not_principals.value.identifiers
+        }
+      }
+
+      dynamic "condition" {
+        for_each = try(statement.value.conditions, [])
+
+        content {
+          test     = condition.value.test
+          values   = condition.value.values
+          variable = condition.value.variable
+        }
+      }
+    }
+  }
+}
+
+# --------------------------------
+# Resource    : SQS Queue Policy
+# Description : Attaches policy to the queue
+# --------------------------------
+resource "aws_sqs_queue_policy" "this" {
+  count = var.enabled && var.create_queue_policy ? 1 : 0
+
+  queue_url = aws_sqs_queue.default[0].url
+  policy    = data.aws_iam_policy_document.this[0].json
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,3 +14,18 @@ output "tags" {
   value       = module.labels.tags
   description = "A mapping of tags to assign to the resource."
 }
+
+output "queue_policy_document" {
+  description = "The generated IAM policy document for the SQS queue"
+  value       = try(data.aws_iam_policy_document.this[0].json, null)
+}
+
+output "queue_policy" {
+  description = "The policy attached to the SQS queue"
+  value       = try(aws_sqs_queue_policy.this[0].policy, null)
+}
+
+output "queue_with_policy_url" {
+  description = "The URL of the SQS queue with the attached policy"
+  value       = try(aws_sqs_queue_policy.this[0].queue_url, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,28 @@ variable "sqs_managed_sse_enabled" {
   default     = false
   description = "Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys."
 }
+
+variable "create_queue_policy" {
+  description = "Whether to create SQS queue policy"
+  type        = bool
+  default     = false
+
+}
+
+variable "source_queue_policy_documents" {
+  description = "List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s"
+  type        = list(string)
+  default     = []
+}
+
+variable "override_queue_policy_documents" {
+  description = "List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid`"
+  type        = list(string)
+  default     = []
+}
+
+variable "queue_policy_statements" {
+  description = "A map of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for custom permission usage"
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
## What

- Added support for attaching IAM policies to SQS queues via `aws_sqs_queue_policy`.
- Uses `aws_iam_policy_document` to dynamically build policies from input variables.
- Supports custom statements, principals, conditions, and overrides.

## why

- Enables flexible, reusable SQS access control through Terraform.
- Supports advanced IAM policy use cases without hardcoding.
- Controlled via enabled and `create_queue_policy` flags.

[references](https://github.com/terraform-aws-modules/terraform-aws-sqs/)